### PR TITLE
Done should also be optional with multiple locks

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = function () {
           var args = [].slice.call(arguments)
           for(var key in l)
             _release(key, l[key])
-          done.apply(this, args)
+          if (done) done.apply(this, args)
         }
       }
 

--- a/test/multi.js
+++ b/test/multi.js
@@ -58,3 +58,19 @@ tape('wait for a single lock', function (t) {
     })()
   })
 })
+
+tape('multiple locks with optional done', function (t) {
+  var lock = Lock(), released = 0
+
+  lock(['a', 'b'], function (release) {
+    released = 1
+    process.nextTick(release())
+  })
+
+  lock(['a', 'b'], function (release) {
+    t.equal(released, 1, 'first lock should be completely released')
+    release(function () {
+      t.end()
+    })()
+  })
+})


### PR DESCRIPTION
Without this method, attempting to call the release function without a callback in place results in `Uncaught TypeError: Cannot call method 'apply' of undefined` at index.js:47.

Please let me know if the included test is unsatisfactory, it's based on the test in test/index.js.
